### PR TITLE
log: change log format to follow the hipache pattern

### DIFF
--- a/log.go
+++ b/log.go
@@ -74,7 +74,7 @@ func (l *Logger) logWriter() {
 	defer l.writer.Close()
 	for el := range l.logChan {
 		nowFormatted := el.now.Format(TIME_ALIGNED_NANO)
-		fmt.Fprintf(l.writer, "%s %s %s %s %d in %0.6f ms\n", nowFormatted, el.req.Host, el.req.Method, el.req.URL.Path, el.rsp.StatusCode, float64(el.duration)/float64(time.Millisecond))
+		fmt.Fprintf(l.writer, "%s - - [%s] %s %s %s %d <socketBytesWritten> %s %s <virtualhost> <totaltime> %0.6f\n", el.req.RemoteAddr, nowFormatted, el.req.Method, el.req.URL.Path, el.req.Proto, el.rsp.StatusCode, el.req.Referer(), el.req.UserAgent(), float64(el.duration)/float64(time.Millisecond))
 	}
 }
 

--- a/router_test.go
+++ b/router_test.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"reflect"
 	"strings"
 	"testing"
@@ -66,10 +65,8 @@ func (s *S) TestRoundTrip(c *check.C) {
 	c.Assert(string(data), check.Equals, "my result")
 	router.logger.Stop()
 	msgs := strings.Split(buf.String(), "\n")
-	testUrl, err := url.Parse(ts.URL)
-	c.Assert(err, check.IsNil)
 	c.Assert(msgs, check.HasLen, 2)
-	c.Assert(msgs[0], check.Matches, fmt.Sprintf(`.*? %s GET / 200 in .*? ms`, testUrl.Host))
+	c.Assert(msgs[0], check.Matches, ".*? GET / HTTP/1.1 .*?")
 	c.Assert(msgs[1], check.Equals, "")
 }
 


### PR DESCRIPTION
change log format to follow the hipache pattern

the log info is incomplete is missing data for virtualhost,
socketBytesWritten and totaltime.